### PR TITLE
Adding Credits To Katto-Studios & Fix Linking For Freepik Credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ Open a new terminal window and type typr. It should execute your typr applicatio
 ___You can also run ```typr -h``` to output the manual page for the application to see all the addional run-time flags you can utilize.___
 
 ## Acknowledgements
-- [Freepik.com]((https://www.freepik.com/free-vector/cute-astronaut-working-with-laptop-space-cartoon-vector-icon-illustration-science-technology_42161336.htm#query=keyboard&position=13&from_view=search&track=sph)
-) for astronaut logo
+- [Freepik.com](https://www.freepik.com/free-vector/cute-astronaut-working-with-laptop-space-cartoon-vector-icon-illustration-science-technology_42161336.htm#query=keyboard&position=13&from_view=search&track=sph) for astronaut logo
 
-- [katto-studios]((https://github.com/katto-studios/loki)) for the default wordlist
+- [katto-studios](https://github.com/katto-studios/loki) for the default word list
 
 ___(Image by catalyststuff on Freepik)___

--- a/README.md
+++ b/README.md
@@ -75,4 +75,6 @@ ___You can also run ```typr -h``` to output the manual page for the application 
 - [Freepik.com]((https://www.freepik.com/free-vector/cute-astronaut-working-with-laptop-space-cartoon-vector-icon-illustration-science-technology_42161336.htm#query=keyboard&position=13&from_view=search&track=sph)
 ) for astronaut logo
 
+- [katto-studios]((https://github.com/katto-studios/loki)) for the default wordlist
+
 ___(Image by catalyststuff on Freepik)___

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,13 @@ maintainers = [
 ]
 
 classifiers = [
-  "Development Status :: Staging",
+  #   3 - Alpha
+  #   4 - Beta
+  #   5 - Production/Stable
+  "Development Status :: Stable",
 
   "Intended Audience :: Typing Entusiasts",
-  "Topic :: CLI Applications",
+  "Topic :: CLI Applications :: Typing Test Application",
 
   "License :: OSI Approved :: GPL-3.0 license",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,10 @@ maintainers = [
 ]
 
 classifiers = [
-  #   3 - Alpha
-  #   4 - Beta
-  #   5 - Production/Stable
-  "Development Status :: Stable",
+  "Development Status :: Staging",
 
   "Intended Audience :: Typing Entusiasts",
-  "Topic :: CLI Applications :: Typing Test Application",
+  "Topic :: CLI Applications",
 
   "License :: OSI Approved :: GPL-3.0 license",
 


### PR DESCRIPTION
I have added a credit to Katto-Studios for the default word list used. Additionally, I have fixed the markdown linking for the Freepik credit. 

Lastly, updated current version.